### PR TITLE
Documentation edits 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ remote and refspec will allow the make_note sub-command to push the changes to t
 
 ### Configuring Editor
 
-By default, the editor used to modify the text files is `xdg-open`.  Depending on the editor that currently set as the 
+By default, the editor used to modify the text files is `xdg-open`.  Depending on the editor that is currently set as the 
 default, this may not work correctly.  For example, executing `gvim` will automatically return when the editor is 
 opened instead of waiting for the user to save and close the file.  To get around this, you will need to set the value
 of the editor to something more sane.  To continue the example of gvim, the setting is:

--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -1,6 +1,6 @@
 # Git Storage Plugin
 
-This plugin is responsible for wrapping the git repostiory that the content files will be stored in.  Currently, this 
+This plugin is responsible for wrapping the git repository that the content files will be stored in.  Currently, this 
 is the only storage plugin that is available.
 
 ## Configuration

--- a/docs/reports/project.md
+++ b/docs/reports/project.md
@@ -39,7 +39,7 @@ filename extension that is provided.
 
 The processor will split the markdown files into the front matter meta data and the content.  It hands the content of 
 the front matter to the YAML Data parser to determine if there are new projects, customers, or organizations defined. 
-Please see the next section for documentation on that functionality.
+Please see the next section below for documentation on that functionality.
 
 In addition to looking for new definitions, it is also responsible for determining the time tracking values for projects
 that are defined elsewhere.  In this case it will look to see if the `mkl-project` key exists and will then use that 

--- a/docs/templates/configuring.md
+++ b/docs/templates/configuring.md
@@ -3,7 +3,7 @@
 ## Configuration File
 
 The settings associated with a template implementation are stored in the `template.yaml` file.  This file should be at
-the root of the template definition.  It contains a list of parameters that will define how the template is instaleld 
+the root of the template definition.  It contains a list of parameters that will define how the template is installed 
 into the root log directory as well as how the templates should be treated by the publishing engine.
 
 ### Configuration Details
@@ -14,7 +14,7 @@ into the root log directory as well as how the templates should be treated by th
   
 - `static_files`
 
-  > This provides a list of file globs that are used to copy static (non-template) files into the final output 
+  > This provides a list of file globs (glob patterns specify sets of file names with wildcard characters) that are used to copy static (non-template) files into the final output 
   > directory.  The most common use of this is for any javascript or css files that must be provided as part of the 
   > output.
   


### PR DESCRIPTION
Updated typos, grammar, and clarifying statements in multiple documentation files. (export_log_templates, configuring, README, and project)